### PR TITLE
Disable PHP Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Prepare
+        run: |
+          echo UID=`id -u` >> $GITHUB_ENV
+          echo GID=`id -g` >> $GITHUB_ENV
+      - name: Build
+        run: docker-compose build
+        env:
+          PHP_VERSION: ${{ matrix.php_version }}
       - name: Install
-        uses: php-actions/composer@v5
-        with:
-          php_version: ${{ matrix.php_version }}
+        run: docker-compose run romans composer install
       - name: Test
-        uses: php-actions/composer@v5
-        with:
-          php_version: ${{ matrix.php_version }}
-          command: test
+        run: docker-compose run romans composer test
+      - name: Clean
+        run: docker-compose down

--- a/README.md
+++ b/README.md
@@ -185,11 +185,9 @@ You can use Docker Compose to build an image and run a container to develop and
 test this package.
 
 ```bash
-docker-compose up --detach
-
-docker-compose exec romans composer install
-
-docker-compose exec romans composer test
+docker-compose build
+docker-compose run romans composer install
+docker-compose run romans composer test
 ```
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,10 @@ version: "3.8"
 services:
 
   romans:
-    build: "./docker-compose"
+    build:
+      context: "./docker-compose"
+      args:
+        PHP_VERSION: "${PHP_VERSION:-8.0}"
     volumes:
     - ".:/app"
     user: "${UID:-1000}:${GID:-1000}"

--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:8.0-cli-alpine
+ARG PHP_VERSION
+
+FROM php:${PHP_VERSION}-cli-alpine
 
 ENV COMPOSER_CACHE_DIR /tmp
 


### PR DESCRIPTION
This PR changes GitHub Actions to use manually running instead of PHP Actions to avoid trashing GitHub Packages trashing.